### PR TITLE
updates in Berry et al 2019

### DIFF
--- a/doc/template.PRM
+++ b/doc/template.PRM
@@ -26,6 +26,7 @@ zini		0	Initial altitude [m] above sea level (added to the initial
 random_topo	0	Adds noise to initial topo between -random_topo/2 and 
 				+random_topo/2 [m]. The computation of lake drainage can become
 				much slower using a high value.
+switch_random_time      0       1 to query the CPU clock for random seed
 
 #DENSITIES [kg/m3]:
 densasthen	3200	Density beneath the lithospheric plate, at the isostatic
@@ -150,20 +151,20 @@ erosed_model	0	Defines the erosion/sedimentation model.
 			#1: constant-rate scheme + hillslope diffusion + landsliding. Non 
 				conservative.
 			#2: As #1 + rivers following undercapacity model (Beaumont et al.,
-				1992): qeq=K_river_cap稱稴 and dq/dl=1/erodability*(q-qeq)
+				1992): qeq=K_river_cap路Q路S and dq/dl=1/erodability*(q-qeq)
 				(reaction equation).
 			#3: As #1 + rivers following Tucker&Slingerland(1996) model.
 				Incision rate under equilibrium capacity (q<qeq):
-				dh/dt=erodibility稱^(1/3)稴^(2/3) with qeq=K_river_cap稱稴 
-			#4: As #2 but m/n=1.5 in the eq. transport capacity: qeq=K稱^m稴^n
+				dh/dt=erodibility路Q^(1/3)路S^(2/3) with qeq=K_river_cap路Q路S 
+			#4: As #2 but m/n=1.5 in the eq. transport capacity: qeq=K路Q^m路S^n
 			#5: As #1 + rivers following undercapacity model (van der Beek &
 				Bishop, 2003; also described in Cowie et al., 2006),
-				implementing channel width in Beaumont's. qeq=K/W稱^m稴^n
+				implementing channel width in Beaumont's. qeq=K/W路Q^m路S^n
 			#6: As #1 + rivers following hybrid detachment+transport limited
 				model, based on the basal shear stress law (formulation and
 				values in Garcia-Castellanos & Jimenez-Munt, PlosONE, 2015), accounting
-				for channel width: dh/dt=K'稱^m稴^n if q<qeq,
-				qeq=K_river_cap稱稴 where K' is a function of K in dh/dz =
+				for channel width: dh/dt=K'路Q^m路S^n if q<qeq,
+				qeq=K_river_cap路Q路S where K' is a function of K in dh/dz =
 				K*tau^1.5 and K is given through 'erodibility'. Erosion
 				gradually decreases to 0 when approaching the eq. capacity
 				defined in #2.
@@ -171,7 +172,7 @@ erosed_model	0	Defines the erosion/sedimentation model.
 				w=rho*g*Q*S/W, with w in [W/m^2], e in mm/yr (Ferrier et al.,
 				2013, Nature).
 				
-Keroseol	.0	Continental background erosion rate (ratio per My, [m/(m稭y)]).
+Keroseol	.0	Continental background erosion rate (ratio per My, [m/(m路My)]).
 Ksedim  	0e2	Additional sedimentation rate below sea level [m/My].
 Kerosdif   	.00	Diffusive transport coefficient [m2/yr] (e.g., Ks in 
 				Kooi&Beaumont,1994,p12193). Tucker&Bras(1998, WaterRes);
@@ -230,6 +231,8 @@ K_ice_eros	0	Constant of ice incision rate relating ice sliding velocity to
 				Processes, David Drewry, 1987), imply [.05e-3-.2e-3]. Tomkin's
 				thesis and Braun et al., 2001, J. Climatology, use [2.5e-3 -
 				.1e-3].
+				
+tau_c           0       critical basal shear required for incision (Case #8)
 
 #INPUT/OUTPUT:
 verbose_level	1	Specify the level of runtime prints in stdout:
@@ -244,6 +247,11 @@ switch_files	1	For extra file output: see files *.bas *.all *.lakes in
 mode_interp	4	Default interpolation mode for input files. See
 				doc/template.UNIT.
 switch_ps	1	For postscript graphic output (uses GMT4 shell scripts).
+switch_3dtopo   0       For postscript graphic output to make 3D topography (Uses GMT4 shell script) tisc.topo3D.gmt.job should be in directory
+switch_profile  0       For postscript graphic output to make 2D river longitudinal profile (uses GMT4 shell scripts) tisc.river_profile.gmt.job should be in directory
+
+write_file_topo 0       1 to print topography file every dt (.xyz file)
+switch_basin_out 0      1 to print drainage network every dt (creates .qwqs file, pulls from .xyw file, the -Pc flag must in the commandline)
 
 
 

--- a/doc/template.PRM
+++ b/doc/template.PRM
@@ -171,6 +171,8 @@ erosed_model	0	Defines the erosion/sedimentation model.
 			#7: As #1 + river incision following unit stream power e=k_b*w^1;
 				w=rho*g*Q*S/W, with w in [W/m^2], e in mm/yr (Ferrier et al.,
 				2013, Nature).
+			#8: Similar to #6 adds uses tau_c for critical shear stress needed for incision and incorporates a 
+				Sklar-like abrasion curve that both aides or inhibits erosion (Berry et al., 2019, in revision)
 				
 Keroseol	.0	Continental background erosion rate (ratio per My, [m/(m·My)]).
 Ksedim  	0e2	Additional sedimentation rate below sea level [m/My].

--- a/include/tao+tisc.h
+++ b/include/tao+tisc.h
@@ -106,6 +106,13 @@ BOOL	switch_dt_output=NO,
 	switch_write_file_Blocks, 	/*YES if Blocks (profile *.pfl) file is to be written*/
 	deform_sed;			/*YES to deform sediment automatically, based on Blocks motion*/
 
+/*new variables by M Berry*/
+BOOL    switch_topo_out, // YES to output the topography every tectonic timestep
+        switch_rand_time, // YES query the CPU clock for the input seed, ensures a slightly different random topo every iteration
+        switch_basin_out,       // YES to output the bas file every timestep.
+        diff_loss, // yes to have water loss rate dependant on channel width
+        switch_profile, //Yes to output river profile every dt
+        switch_3dtopo;  //YES to output 3D topography every dt
 
 /*FUNCTION DECLARATIONS:*/
 float 	*alloc_array		(int num_fil);

--- a/src/tisc.c
+++ b/src/tisc.c
@@ -283,6 +283,9 @@ int inputs (int argc, char **argv)
 	read_file_rain(precipitation_file);
 
 	switch_initial_geom = read_file_initial_deflection(w) + read_file_initial_topo(topo) ;
+	if (switch_rand_time)
+		srand(time(NULL)); // pulls random seed generator from CPU clock, makes every topography unique (M Berry)
+
 	for (i=0; i<Ny; i++)  for (j=0; j<Nx; j++)  
 		topo[i][j] += random_topo * ((((float) rand()) / ((float) RAND_MAX)) -.5);
 	read_file_initial_rivers();
@@ -1412,6 +1415,9 @@ int Write_Ouput()
 	write_file_lakes();
 	write_file_velocity_field();
 	write_file_resume();
+	if (switch_topo_out){  /*M Berry*/
+		write_file_topo();
+	 }
 
 	/*Make GMT Postscript*/
 	if (switch_ps) {
@@ -1430,6 +1436,30 @@ int Write_Ouput()
 			if (verbose_level>=3)
 				fprintf(stdout, "\n%s\n", command) ;
 			system(command);
+			
+			/* new code by m berry */
+
+			if (switch_3dtopo) {
+				if (n_image >= 1){
+				sprintf(command, "./tisc.topo3D.gmt.job %s", projectname);
+			  //execve("./tisc.river_profile.gmt.job", [projectname], []);
+				system(command);
+				sprintf(command, "convert -density 200 %s.ps -interlace NONE  %s_3Dtopo%03d.jpg",
+				projectname, projectname, n_image);
+				system(command);
+				}
+			}
+			if (switch_profile) {
+				if (n_image >= 1){
+				sprintf(command, "./tisc.river_profile.gmt.job %s", projectname);
+				//execve("./tisc.river_profile.gmt.job", [projectname], []);
+				system(command);
+				sprintf(command, "convert -density 200 %s.ps -interlace NONE  %s_prof%03d.jpg",
+				projectname, projectname, n_image);
+				system(command);
+				}
+			}
+			/*end of new code */
 			n_image++;
 		}
 	}

--- a/src/tiscio.c
+++ b/src/tiscio.c
@@ -584,7 +584,12 @@ int read_file_resume(char *filename)
 	fread(&switch_topoest, 		sizeof(BOOL),		1, 	file);
 	fread(&switch_write_file_Blocks, sizeof(BOOL),		1, 	file);
 	fread(&deform_sed, sizeof(BOOL),		1, 	file);
-
+	fread(&tau_c, sizeof(float),       1,      file); //added by mberry
+        fread(&switch_profile, sizeof(BOOL), 1, file); // M BERRY
+        fread(&switch_basin_out, sizeof(BOOL), 1, file); // M BERRY
+        fread(&switch_3dtopo, sizeof(BOOL), 1, file); // M BERRY
+        fread(&diff_loss, sizeof(BOOL), 1, file); // M Berry
+        fread(&switch_rand_time, sizeof(BOOL), 1, file); // M Berry	
 
 	/*Defined in tisc.h:*/
 	fread(&erosed_model, 		sizeof(int),		1, 	file);
@@ -1377,9 +1382,19 @@ int write_file_drainage ()
 	}
 	fclose(file);
 #endif
+
+//new code by m berry
+	if (switch_basin_out){
+		char 	command[300];
+		if (n_image >= 1){
+		sprintf(command, "awk '{print $1, $2, $7, $8, $3, $4}' %s.xyw > %s_%03d.qwqs", projectname, projectname,n_image);
+//x , y, x-to, y-to, q_w, q_s
+		system(command);
+		}
+	}
+	/*end of new code */
 	return (1);
 }
-
 
 
 
@@ -1671,7 +1686,12 @@ int write_file_resume()
 	fwrite(&switch_topoest, 		sizeof(BOOL),		1, 	file);
 	fwrite(&switch_write_file_Blocks, sizeof(BOOL),		1, 	file);
 	fwrite(&deform_sed, sizeof(BOOL),		1, 	file);
-
+	fwrite(&tau_c, sizeof(float),   1,      file);				// M BERRY
+        fwrite(&switch_profile, sizeof(BOOL), 1, file); 			// M BERRY
+        fwrite(&switch_3dtopo, sizeof(BOOL), 1, file);				// M BERRY
+        fwrite(&switch_basin_out, sizeof(BOOL), 1, file);			// M BERRY
+        fwrite(&diff_loss, sizeof(BOOL), 1, file); 				// M BERRY
+        fwrite(&switch_rand_time, sizeof(BOOL), 1, file); 			// M BERRY	
 
 	/*Defined in tisc.h:*/
 	fwrite(&erosed_model, 	sizeof(int),		1, 	file);
@@ -1908,6 +1928,27 @@ int write_file_deflection ()
 	return (1);
 }
 
+/*== write topo file every tectonic iteration (M Berry)===*/
+int write_file_topo()
+{
+	int 	i, j;
+	FILE 	*file;
+	Write_Open_Filename_Return(".xyz","wt",!switch_write_file_Blocks);
+
+
+ //fprintf(file, "#TISC output: topo surface at Time: %.2f My.\n #x(km) y(km) topo[m]\n", Time/Matosec);
+	for (i=0; i<Ny; i++) for (j=0; j<Nx; j++) {
+ 		fprintf(file, "%7.2f\t%7.2f\t%.1f\n",
+			(xmin+j*dx)/1000, (ymax-i*dy)/1000,
+			topo[i][j]);
+		}
+		fclose(file);
+		char command2[300];
+		sprintf(command2, "cp %s.xyz %s%03d.xyz", projectname, projectname, n_image);
+		system(command2);
+		//$$
+		return (1);
+}
 
 
 int write_file_velocity_field ()


### PR DESCRIPTION
Hi Daniel,

I have included the changes that I built for Berry et al 2019 including a new incision equation which has a sediment tool/cover curve (eros_model 8) and water loss rate with is connected to stream width (dischage).

The diff_loss section found in surf_proc.c I think was giving me headaches, so it would be worth double checking that. 

I linked these changes to your newest edition and it seemed to work on my end, but I am still trying to get a handle on how to do this in GitHub so if there is problems, it is most likely due to a change that I made on my end not getting on this (i.e. missing changes)

If you want to fix any of my formattings, please feel free to make any adjustments you see fit.
And of course, please contact me with problems and I will fix them promptly. 